### PR TITLE
Pass `--region` and `--no-sign-request` options to the aws-cli example

### DIFF
--- a/Metadata/Download/README.md
+++ b/Metadata/Download/README.md
@@ -17,11 +17,11 @@ The metadata files are stored in the iNaturalist Open Dataset as follows:
 You can use the [AWS Command Line Interface (CLI)](https://aws.amazon.com/cli/) to download the complete bundle, or each file separately. For example to download the bundle you can use:
 
 ```
-aws s3 --region us-east-1 cp s3://inaturalist-open-data/metadata/inaturalist-open-data-latest.tar.gz inaturalist-open-data-latest.tar.gz
+aws s3 --no-sign-request --region us-east-1 cp s3://inaturalist-open-data/metadata/inaturalist-open-data-latest.tar.gz inaturalist-open-data-latest.tar.gz
 ```
 
 To download just the photos file you can use:
 
 ```
-aws s3 --region us-east-1 cp s3://inaturalist-open-data/photos.csv.gz photos.csv.gz
+aws s3 --no-sign-request --region us-east-1 cp s3://inaturalist-open-data/photos.csv.gz photos.csv.gz
 ```

--- a/Metadata/Download/README.md
+++ b/Metadata/Download/README.md
@@ -17,11 +17,11 @@ The metadata files are stored in the iNaturalist Open Dataset as follows:
 You can use the [AWS Command Line Interface (CLI)](https://aws.amazon.com/cli/) to download the complete bundle, or each file separately. For example to download the bundle you can use:
 
 ```
-aws s3 cp s3://inaturalist-open-data/metadata/inaturalist-open-data-latest.tar.gz inaturalist-open-data-latest.tar.gz
+aws s3 --region us-east-1 cp s3://inaturalist-open-data/metadata/inaturalist-open-data-latest.tar.gz inaturalist-open-data-latest.tar.gz
 ```
 
 To download just the photos file you can use:
 
 ```
-aws s3 cp s3://inaturalist-open-data/photos.csv.gz photos.csv.gz
+aws s3 --region us-east-1 cp s3://inaturalist-open-data/photos.csv.gz photos.csv.gz
 ```


### PR DESCRIPTION
Unless the region is explicitly configured in the local config file or passed as a command line option, the download will fail with fatal error, at least on Linux (using latest `aws-cli` release):


```bash
aws s3 cp s3://inaturalist-open-data/metadata/inaturalist-open-data-latest.tar.gz inaturalist-open-data-latest.tar.gz
# fatal error: Could not connect to the endpoint URL: "https://inaturalist-open-data.s3.nov.amazonaws.com/metadata/inaturalist-open-data-latest.tar.gz"
```

Specifying the region is necessary in order to connect to the correct endpoint.

The `--no-sign-request` is required when bucket credentials are not provided by the user. If not passed, aws-cli will try to locate the `credentials` for the bucket.

```
fatal error: Unable to locate credentials
```

This PR updates the two examples in `Metadata/Download/README.md` to add the two options for public download.